### PR TITLE
Solve memory issues on CPP_STD CAS kernels

### DIFF
--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
@@ -285,6 +285,13 @@ bool CT_CPP_STD::AllocateData(uint64_t m,
     return false;
   }
 
+  expected = new (std::nothrow) uint64_t[iters*pes];
+  if( expected == nullptr ) {
+    std::cout << "CT_CPP_STD::AllocateData : 'expected' could not be allocated" << std::endl;
+    delete[] expected;
+    return false;
+  }
+
   // initiate the random array
   srand(time(NULL));
   if( this->GetBenchType() == CT_PTRCHASE ){
@@ -312,6 +319,10 @@ bool CT_CPP_STD::FreeData(){
   if( Idx ){
     delete[] Idx;
   }
+  if( expected ){
+    delete[] expected;
+  }
+
   return true;
 }
 

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
@@ -38,6 +38,7 @@ private:
   uint64_t iters;                       ///< CT_CPP_STD: Number of iterations per thread
   uint64_t elems;                       ///< CT_CPP_STD: Number of u8 elements
   uint64_t stride;                      ///< CT_CPP_STD: Stride in elements
+  uint64_t* expected;                   ///< CT_CPP_STD: Expected Array for CAS kernels
 
 public:
   /// CircusTent C++ standard atomics constructor

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
@@ -40,10 +40,9 @@ void CT_CPP_STD::RAND_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i]];
   }
 
   // Wait for all threads to be spawned
@@ -56,7 +55,7 @@ void CT_CPP_STD::RAND_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[Idx[start+i]].compare_exchange_strong(expected[i], Array[Idx[start+i]], std::memory_order_relaxed);
+    Array[Idx[start+i]].compare_exchange_strong(expected[(thread_id*iters)+i], Array[Idx[start+i]], std::memory_order_relaxed);
   }
 }
 
@@ -88,10 +87,9 @@ void CT_CPP_STD::STRIDE1_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+i];
+    expected[(thread_id*iters)+i] = Array[start+i];
   }
 
   // Wait for all threads to be spawned
@@ -104,7 +102,7 @@ void CT_CPP_STD::STRIDE1_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[start+i].compare_exchange_strong(expected[i], Array[start+i], std::memory_order_relaxed);
+    Array[start+i].compare_exchange_strong(expected[(thread_id*iters)+i], Array[start+i], std::memory_order_relaxed);
   }
 }
 
@@ -136,10 +134,9 @@ void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters * stride;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+(stride*i)];
+    expected[(thread_id*iters)+i] = Array[start+(stride*i)];
   }
 
   // Wait for all threads to be spawned
@@ -152,7 +149,7 @@ void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[start+(stride*i)].compare_exchange_strong(expected[i], Array[start+(stride*i)], std::memory_order_relaxed);
+    Array[start+(stride*i)].compare_exchange_strong(expected[(thread_id*iters)+i], Array[start+(stride*i)], std::memory_order_relaxed);
   }
 }
 
@@ -229,10 +226,9 @@ void CT_CPP_STD::SG_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i+1]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i+1]];
   }
 
   // Wait for all threads to be spawned
@@ -253,8 +249,8 @@ void CT_CPP_STD::SG_CAS(uint64_t thread_id,
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[src].compare_exchange_strong(val, Array[src], std::memory_order_relaxed);
     // AMO #4 issue - expected may not equal Array[dest] due to previous ops
-    // Result: expected[i] <- Array[dest] rather than Array[dest] <- val
-    Array[dest].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    // Result: expected[(thread_id*iters)+i] <- Array[dest] rather than Array[dest] <- val
+    Array[dest].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 
@@ -331,10 +327,9 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i+1]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i+1]];
   }
 
   // Wait for all threads to be spawned
@@ -353,8 +348,8 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[start+i].compare_exchange_strong(val, Array[start+i], std::memory_order_relaxed);
     // AMO #3 issue - expected may not equal Array[dest] due to previous ops
-    // Result: expected[i] <- Array[dest] rather than Array[dest] <- val
-    Array[dest].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    // Result: expected[(thread_id*iters)+i] <- Array[dest] rather than Array[dest] <- val
+    Array[dest].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 
@@ -390,10 +385,9 @@ void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+i];
+    expected[(thread_id*iters)+i] = Array[start+i];
   }
 
   // Wait for all threads to be spawned
@@ -411,7 +405,7 @@ void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
   for(i = 0; i < iters; i++){
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[dest].compare_exchange_strong(val, Array[dest], std::memory_order_relaxed);
-    Array[start+i].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    Array[start+i].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 


### PR DESCRIPTION
Some executions were running out of stack memory and we were not checking memory allocation for the expected[] arrays used in CPP_STD backend. Now, I am allocating them dynamically and doing that check as we do for Idx[], Array[]